### PR TITLE
Rewrite main to update, and use GITHUB_REF_NAME

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -10,7 +10,7 @@ branch=${GITHUB_REF_NAME}
 
 # Use the branch name to choose the name of the branch. This assumes
 # no branch of name 'update' will ever be used.
-if [[ $branch = master ]];
+if [[ $branch = master || $branch = main ]];
 then
   update=update
 else

--- a/upload.sh
+++ b/upload.sh
@@ -6,7 +6,7 @@ branch=$2
 version=$3
 url=$4
 remote=$5
-branch=${GITHUB_REF##*/}
+branch=${GITHUB_REF_NAME}
 
 # Use the branch name to choose the name of the branch. This assumes
 # no branch of name 'update' will ever be used.


### PR DESCRIPTION
I thought I'd put this PRQ in yesterday but GitHub ate it, hmm.

The reason I'm proposing these changes is a) to fix up behaviour when ga-eclipse-deploy is confronted with a repository that uses 'main' as its main branch (as with most recently created git/github repositories), and also to use `GITHUB_REF_NAME` as a [more direct environment variable](https://docs.github.com/en/actions/learn-github-actions/environment-variables) for getting the current branch.

I'll be testing both of these on robocert-textual in a bit, as it's hard to test this outside of running an action.